### PR TITLE
docs: use docker compose in getting started guide

### DIFF
--- a/content/documentation/getting-started.md
+++ b/content/documentation/getting-started.md
@@ -21,17 +21,13 @@ Let's get started!
 ## Prerequisites
 
 - [Install Docker](https://docs.docker.com/get-docker/) for your OS.
-- [Install PSQL](https://www.postgresql.org/download/) for your OS.
 
-Now you can clone the example repository into a location of your choosing.
+Clone the example repository into a location of your choosing.
 
 ```bash
 git clone https://github.com/iwpnd/tegola-example-bonn.git
 cd tegola-example-bonn
 ```
-
-Now you download and unzip the
-[Bonn dataset](https://github.com/go-spatial/tegola-example-data/raw/master/bonn_osm.sql.tar.gz) and put `bonn_osm.dump` into the `bin/` directory.
 
 Next up, you start Tegola and Postgres/PostGIS in a containerized environment
 
@@ -39,23 +35,21 @@ Next up, you start Tegola and Postgres/PostGIS in a containerized environment
 docker compose up
 ```
 
-With the following you load the Bonn example data into your
-recently started Postgres/PostGIS database.
+This will take care of
 
-```bash
-PGPASSWORD=postgres sh bin/init.sh
-```
+- unpacking the example data
+- starting all required services
+- database migration
+
+wait until the migration step exits and you're done.
 
 ## Tegola viewer
 
-This examples comes with two providers.
+This example comes with the `mvt_postgis` provider. After you ran the prerequisites,
+you can access the tegola viewer via `http://localhost:8080`.
 
-- the `postgis` provider via `http://localhost:8081`
-- the `mvt_postgis` provider via `http://localhost:8080`
-
-(for more on the differences see [provider layers]({{< ref "/documentation/configuration#provider-layers" >}} "provider layers").
-
-Either will great you with Tegola's build-in viewer:
+(for more on the differences see
+[provider layers]({{< ref "/documentation/configuration#provider-layers" >}} "provider layers").
 
 ![Bonn, Germany](/images/bonn_internal_viewer.png)
 
@@ -123,5 +117,9 @@ If everything was successful, you should see a map of Bonn in your browser.
 
 ## Next steps
 
-Check out our other [tutorials]({{< ref "/tutorials" >}} "tutorials") and start
-using your own data!
+- Check out how to create your own
+  [config]({{< ref "/documentation/configuration" >}} "tutorials")
+- Check out our other [tutorials]({{< ref "/tutorials" >}} "tutorials") and start
+  using your own data!
+- Join [gophers#go-spatial on slack](https://app.slack.com/client/T029RQSE6/C029RQSEE/)
+  and show us what you built with tegola!

--- a/content/documentation/getting-started.md
+++ b/content/documentation/getting-started.md
@@ -25,7 +25,7 @@ Let's get started!
 Clone the example repository into a location of your choosing.
 
 ```bash
-git clone https://github.com/iwpnd/tegola-example-bonn.git
+git clone https://github.com/go-spatial/tegola-example-bonn.git
 cd tegola-example-bonn
 ```
 

--- a/content/documentation/getting-started.md
+++ b/content/documentation/getting-started.md
@@ -10,127 +10,61 @@ menu:
     parent: Documentation
 ---
 
-## 1. Download Tegola
+The quickest way to your first vector tile server is via using this
+example [repository](https://github.com/iwpnd/tegola-example-bonn).
+At the end of this exercise you will have an understanding of how
+to setup and configure Tegola. You will also have created your first
+client application utilizing vector tiles.
 
-### Executable
-[Choose the binary](https://github.com/go-spatial/tegola/releases) that matches the operating system Tegola will run on. Find the Tegola file that was downloaded, unzip it, and move it into a fresh directory. Rename this file `tegola`.
+Let's get started!
 
-### Docker Image
-Tegola provides an official Docker release with support for both PostGIS and GeoPackage data providers.  Use `docker pull gospatial/tegola` to get the latest image.
+## Prerequisites
 
-[Check out the docs on Docker Hub](https://hub.docker.com/r/gospatial/tegola/) for details and examples of using the image.
+- [Install Docker](https://docs.docker.com/get-docker/) for your OS.
+- [Install PSQL](https://www.postgresql.org/download/) for your OS.
 
-## 2. Set up a data provider
+Now you can clone the example repository into a location of your choosing.
 
-Tegola needs geospatial data to run. Currently, Tegola supports PostGIS which is a geospatial extension for PostgreSQL, and GeoPackage. If you don't have PostGIS installed, [download PostGIS](http://postgis.net/install/).
-
-Next, you'll need to load PostGIS with data. For your convenience you can download [PostGIS data for Bonn, Germany](https://github.com/go-spatial/tegola-example-data/raw/master/bonn_osm.sql.tar.gz).
-
-Create a new database named `bonn`:
-
-```sh
-psql -c 'CREATE DATABASE bonn;'
+```bash
+git clone https://github.com/iwpnd/tegola-example-bonn.git
+cd tegola-example-bonn
 ```
 
- Use the restore command to import the unzipped SQL file into the database. Documentation can be found [here](https://www.postgresql.org/docs/current/static/backup.html) under the section titled "Restoring the dump". The command should look something like this:
+Now you download and unzip the
+[Bonn dataset](https://github.com/go-spatial/tegola-example-data/raw/master/bonn_osm.sql.tar.gz) and put `bonn_osm.dump` into the `bin/` directory.
 
-```sh
-psql bonn < bonn_osm.dump
+Next up, you start Tegola and Postgres/PostGIS in a containerized environment
+
+```bash
+docker compose up
 ```
 
-To enable Tegola to connect to the database, create a database user named `tegola` and grant the privileges required to read the tables in the `public` schema of the `bonn` database, using these commands:
+With the following you load the Bonn example data into your
+recently started Postgres/PostGIS database.
 
-```sh
-psql -c "CREATE USER tegola;"
-psql -d bonn -c "GRANT SELECT ON ALL TABLES IN SCHEMA public TO tegola;"
+```bash
+PGPASSWORD=postgres sh bin/init.sh
 ```
 
-## 3. Create a configuration file
+## Tegola viewer
 
-Tegola utilizes a single configuration file to coordinate with data provider(s). This configuration file is written in [TOML format](https://github.com/toml-lang/toml).
+This examples comes with two providers.
 
-Create your configuration file in the same directory as the Tegola binary and name it `config.toml`. Next, copy and paste the following into this file:
+- the `postgis` provider via `http://localhost:8081`
+- the `mvt_postgis` provider via `http://localhost:8080`
 
-```toml
-[webserver]
-port = ":8080"
+(for more on the differences see [provider layers]({{< ref "/documentation/configuration#provider-layers" >}} "provider layers").
 
-# register data providers
-[[providers]]
-name = "bonn"           # provider name is referenced from map layers
-type = "postgis"        # the type of data provider. currently only supports postgis
-host = "localhost"      # postgis database host
-port = 5432             # postgis database port
-database = "bonn"       # postgis database name
-user = "tegola"         # postgis database user
-password = ""           # postgis database password
-srid = 4326             # The default srid for this provider. If not provided it will be WebMercator (3857)
-
-  [[providers.layers]]
-  name = "road"
-  geometry_fieldname = "wkb_geometry"
-  id_fieldname = "ogc_fid"
-  sql = "SELECT ST_AsBinary(wkb_geometry) AS wkb_geometry, name, ogc_fid FROM all_roads WHERE wkb_geometry && !BBOX!"
-
-  [[providers.layers]]
-  name = "main_roads"
-  geometry_fieldname = "wkb_geometry"
-  id_fieldname = "ogc_fid"
-  sql = "SELECT ST_AsBinary(wkb_geometry) AS wkb_geometry, name, ogc_fid FROM main_roads WHERE wkb_geometry && !BBOX!"
-
-  [[providers.layers]]
-  name = "lakes"
-  geometry_fieldname = "wkb_geometry"
-  id_fieldname = "ogc_fid"
-  sql = "SELECT ST_AsBinary(wkb_geometry) AS wkb_geometry, name, ogc_fid FROM lakes WHERE wkb_geometry && !BBOX!"
-
-[[maps]]
-name = "bonn"
-center = [7.0982, 50.7374, 11.0] # set the center of the map so the user is auto navigated to Bonn
-
-  [[maps.layers]]
-  provider_layer = "bonn.road"
-  min_zoom = 10
-  max_zoom = 20
-
-  [[maps.layers]]
-  provider_layer = "bonn.main_roads"
-  min_zoom = 5
-  max_zoom = 20
-
-  [[maps.layers]]
-  provider_layer = "bonn.lakes"
-  min_zoom = 5
-  max_zoom = 20
-```
-
-Note: This configuration file is specific to the Bonn data provided in step 2 if you're using another dataset reference the [Configuration Documentation](/documentation/configuration/).
-
-## 4. Start Tegola
-
-### Executable
-
-Navigate to the Tegola directory in your computer's terminal and run this command:
-
-```sh
-./tegola serve --config=config.toml
-```
-
-You should see a message confirming the config file load and Tegola being started on port 8080. If your computer's port 8080 is being used by another process, change the port in the config file to an open port.
-
-Next open up your browser to `localhost:8080` to launch the internal tegola viewer. If everything is working you should see a map of Boon similar to:
+Either will great you with Tegola's build-in viewer:
 
 ![Bonn, Germany](/images/bonn_internal_viewer.png)
 
-### Docker Image
-If you're using the docker image, starting Tegola will be slightly different in order to pass your config and possibly your data into the container.
+## Your first vector map
 
-[Check out the docs on Docker Hub](https://hub.docker.com/r/gospatial/tegola/) for details and examples of using the image.
-
-
-## 5. Create an HTML Page
-
-Tegola delivers geospatial vector tile data to any requesting client. For simplicity, we'll be setting up a basic HTML page as our client that will display the rendered map. We'll be using the [OpenLayers](http://openlayers.org/) client side library to display and style the vector tile content.
+Tegola delivers geospatial vector tile data to any requesting client. For simplicity,
+we'll be setting up a basic HTML page as our client that will display the rendered
+map. We'll be using the [OpenLayers](http://openlayers.org/) client side
+library to display and style the vector tile content.
 
 Create a new HTML file, copy in the contents below, and open in a browser:
 
@@ -139,7 +73,11 @@ Create a new HTML file, copy in the contents below, and open in a browser:
 <html>
   <head>
     <title>Tegola Sample</title>
-    <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css" type="text/css">
+    <link
+      rel="stylesheet"
+      href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css"
+      type="text/css"
+    />
     <script src="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/build/ol.js"></script>
     <style>
       #map {
@@ -157,26 +95,33 @@ Create a new HTML file, copy in the contents below, and open in a browser:
         layers: [
           new ol.layer.VectorTile({
             source: new ol.source.VectorTile({
-              attributions:'© <a href="http://www.openstreetmap.org/copyright">' +
-              'OpenStreetMap contributors</a>',
+              attributions:
+                '© <a href="http://www.openstreetmap.org/copyright">' +
+                "OpenStreetMap contributors</a>",
               format: new ol.format.MVT(),
-              tileGrid: ol.tilegrid.createXYZ({maxZoom: 22}),
+              tileGrid: ol.tilegrid.createXYZ({ maxZoom: 22 }),
               tilePixelRatio: 16,
-              url:'/maps/bonn/{z}/{x}/{y}.vector.pbf?debug=true'
-            })
-          })
+              url: "/maps/bonn/{z}/{x}/{y}.vector.pbf?debug=true",
+            }),
+          }),
         ],
-        target: 'map',
+        target: "map",
         view: new ol.View({
-          center: [790793.4954921771, 6574927.869849075], //coordinates the map will center on initially
-          zoom: 14
-        })
+          //coordinates the map will center on initially
+          center: [790793.4954921771, 6574927.869849075],
+          zoom: 14,
+        }),
       });
     </script>
   </body>
 </html>
 ```
 
-If everything was successful, you should see a map of Bonn in your browser. 
+If everything was successful, you should see a map of Bonn in your browser.
 
 ![Bonn, Germany](/images/bonn.png)
+
+## Next steps
+
+Check out our other [tutorials]({{< ref "/tutorials" >}} "tutorials") and start
+using your own data!


### PR DESCRIPTION
In my opinion a getting-started guide should be the quickest possible way to get you from 0 to hero.
The fastest way is by providing the easier way to setup an environment, which in most cases is docker-compose.
So I use docker compose to guide the user to her first small client application.

What do you think @arolek?